### PR TITLE
chore: .serenaディレクトリをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 # Config files with secrets
 .specverify.yml
 .specverify.yaml
+.serena/


### PR DESCRIPTION
## 概要
Serena（AIコーディングアシスタント）が生成する `.serena/` ディレクトリを `.gitignore` に追加しました。

## 変更内容
- `.gitignore` に `.serena/` を追加

## 理由
Serenaのキャッシュ/設定ディレクトリはリポジトリに含める必要がないため、gitignoreに追加しました。