### PR TITLE
feat: SPECタイプ詳細定義とグループ機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ gh spec-verify check ui    # UIのSPECのみ
 gh spec-verify check api   # APIのSPECのみ
 ```
 
+### 複数タイプを同時検証
+
+```bash
+gh spec-verify check ui api domain   # 複数タイプを一度に検証
+```
+
+### グループ単位で検証
+
+```bash
+gh spec-verify check --group frontend   # フロントエンドグループを検証
+gh spec-verify check -g backend         # バックエンドグループを検証
+```
+
+### 利用可能なタイプ/グループを確認
+
+```bash
+gh spec-verify types    # 定義されているSPECタイプ一覧
+gh spec-verify groups   # 定義されているグループ一覧
+```
+
 ### JSON出力（CI向け）
 
 ```bash
@@ -97,6 +117,8 @@ gh spec-verify check --threshold 70
 
 `.specverify.yml`:
 
+### 基本設定（シンプル）
+
 ```yaml
 # SPECファイルのディレクトリ
 specs_dir: specs/
@@ -107,7 +129,7 @@ code_dir: src/
 # 使用するAIプロバイダー (claude, openai, gemini)
 ai_provider: claude
 
-# SPECタイプごとのコードディレクトリマッピング
+# SPECタイプごとのコードディレクトリマッピング（シンプル形式）
 mapping:
   ui: client/components
   api: server/routes
@@ -121,6 +143,72 @@ options:
   # 詳細出力
   verbose: false
 ```
+
+### 詳細設定（spec_typesとgroups）
+
+```yaml
+specs_dir: specs/
+code_dir: src/
+ai_provider: claude
+
+# SPECタイプの詳細定義
+spec_types:
+  ui:
+    # 検証対象のコードパス（複数指定可能）
+    code_paths:
+      - client/components
+      - client/pages
+    # AI検証時の重点観点
+    verification_focus:
+      - コンポーネント構成
+      - 画面遷移
+      - 状態管理
+
+  api:
+    code_paths:
+      - server/routes
+      - server/handlers
+    verification_focus:
+      - エンドポイント定義
+      - リクエスト/レスポンス形式
+      - 認証・認可
+
+  domain:
+    code_paths:
+      - server/domain
+      - server/models
+    verification_focus:
+      - ビジネスルール
+      - ドメインロジック
+      - バリデーション
+
+  service:
+    code_paths:
+      - server/services
+    verification_focus:
+      - ユースケース実装
+      - トランザクション処理
+
+# グループ定義
+groups:
+  frontend:
+    types: [ui]
+    description: "フロントエンド関連"
+
+  backend:
+    types: [api, domain, service]
+    description: "バックエンド関連"
+
+  all:
+    types: [ui, api, domain, service]
+    description: "全てのSPEC"
+
+options:
+  concurrency: 3
+  pass_threshold: 50
+```
+
+**Note**: `spec_types` と `mapping` の両方が定義されている場合、`spec_types` が優先されます。これにより既存の設定を段階的に移行できます。
 
 ## SPECファイルの書き方
 

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -28,10 +28,19 @@ type EndpointResult struct {
 	Description string `json:"description,omitempty"`
 }
 
+// VerifyOptions は検証時のオプション
+type VerifyOptions struct {
+	// 検証観点（AIへのヒント）
+	VerificationFocus []string
+}
+
 // Provider はAIプロバイダーのインターフェース
 type Provider interface {
 	// Verify はSPECとコードの一致度を検証する
 	Verify(ctx context.Context, specContent string, codeContents map[string]string) (*VerificationResult, error)
+
+	// VerifyWithOptions は検証観点を指定してSPECとコードの一致度を検証する
+	VerifyWithOptions(ctx context.Context, specContent string, codeContents map[string]string, opts *VerifyOptions) (*VerificationResult, error)
 
 	// ExtractEndpoints はコードからAPIエンドポイントを抽出する
 	ExtractEndpoints(ctx context.Context, sourceType string, codeContent string) ([]EndpointResult, error)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,256 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSpecTypesAndGroups(t *testing.T) {
+	// テスト用の設定ファイルを作成
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, ".specverify.yml")
+
+	configContent := `
+specs_dir: specs/
+code_dir: src/
+ai_provider: claude
+
+spec_types:
+  ui:
+    code_paths:
+      - client/components
+      - client/pages
+    verification_focus:
+      - コンポーネント構成
+      - 画面遷移
+
+  api:
+    code_paths:
+      - server/routes
+    verification_focus:
+      - エンドポイント定義
+      - リクエスト/レスポンス形式
+
+  domain:
+    code_paths:
+      - server/domain
+    verification_focus:
+      - ビジネスルール
+      - ドメインロジック
+
+groups:
+  frontend:
+    types: [ui]
+    description: "フロントエンド関連"
+  backend:
+    types: [api, domain]
+    description: "バックエンド関連"
+  all:
+    types: [ui, api, domain]
+    description: "全て"
+
+options:
+  concurrency: 3
+  pass_threshold: 50
+`
+	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	// 設定を読み込む
+	cfg, err := Load(configFile)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// spec_types のテスト
+	t.Run("GetCodePaths", func(t *testing.T) {
+		paths := cfg.GetCodePaths("ui")
+		if len(paths) != 2 {
+			t.Errorf("Expected 2 paths for ui, got %d", len(paths))
+		}
+		if paths[0] != "src/client/components" {
+			t.Errorf("Expected 'src/client/components', got '%s'", paths[0])
+		}
+	})
+
+	t.Run("GetVerificationFocus", func(t *testing.T) {
+		focus := cfg.GetVerificationFocus("api")
+		if len(focus) != 2 {
+			t.Errorf("Expected 2 focus items for api, got %d", len(focus))
+		}
+		if focus[0] != "エンドポイント定義" {
+			t.Errorf("Expected 'エンドポイント定義', got '%s'", focus[0])
+		}
+	})
+
+	t.Run("GetAllSpecTypes", func(t *testing.T) {
+		types := cfg.GetAllSpecTypes()
+		if len(types) != 3 {
+			t.Errorf("Expected 3 types, got %d", len(types))
+		}
+	})
+
+	t.Run("HasSpecType", func(t *testing.T) {
+		if !cfg.HasSpecType("domain") {
+			t.Error("Expected domain to exist")
+		}
+		if cfg.HasSpecType("nonexistent") {
+			t.Error("Expected nonexistent to not exist")
+		}
+	})
+
+	// groups のテスト
+	t.Run("GetTypesByGroup", func(t *testing.T) {
+		types := cfg.GetTypesByGroup("backend")
+		if len(types) != 2 {
+			t.Errorf("Expected 2 types in backend group, got %d", len(types))
+		}
+	})
+
+	t.Run("GetAllGroups", func(t *testing.T) {
+		groups := cfg.GetAllGroups()
+		if len(groups) != 3 {
+			t.Errorf("Expected 3 groups, got %d", len(groups))
+		}
+	})
+
+	t.Run("HasGroup", func(t *testing.T) {
+		if !cfg.HasGroup("frontend") {
+			t.Error("Expected frontend group to exist")
+		}
+		if cfg.HasGroup("nonexistent") {
+			t.Error("Expected nonexistent group to not exist")
+		}
+	})
+
+	t.Run("GetSpecTypeInfo", func(t *testing.T) {
+		info := cfg.GetSpecTypeInfo("domain")
+		if info == nil {
+			t.Fatal("Expected domain info to exist")
+		}
+		if len(info.CodePaths) != 1 {
+			t.Errorf("Expected 1 code path, got %d", len(info.CodePaths))
+		}
+		if len(info.VerificationFocus) != 2 {
+			t.Errorf("Expected 2 verification focus items, got %d", len(info.VerificationFocus))
+		}
+	})
+}
+
+func TestBackwardCompatibility(t *testing.T) {
+	// 従来形式の設定ファイルを作成
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, ".specverify.yml")
+
+	configContent := `
+specs_dir: specs/
+code_dir: src/
+ai_provider: claude
+
+mapping:
+  ui: client/components
+  api: server/routes
+
+options:
+  concurrency: 3
+  pass_threshold: 50
+`
+	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := Load(configFile)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// mapping から GetCodePath が動作することを確認
+	t.Run("GetCodePath from mapping", func(t *testing.T) {
+		path := cfg.GetCodePath("ui")
+		if path != "src/client/components" {
+			t.Errorf("Expected 'src/client/components', got '%s'", path)
+		}
+	})
+
+	// mapping から GetCodePaths が動作することを確認
+	t.Run("GetCodePaths from mapping", func(t *testing.T) {
+		paths := cfg.GetCodePaths("api")
+		if len(paths) != 1 {
+			t.Errorf("Expected 1 path, got %d", len(paths))
+		}
+		if paths[0] != "src/server/routes" {
+			t.Errorf("Expected 'src/server/routes', got '%s'", paths[0])
+		}
+	})
+
+	// mapping から GetAllSpecTypes が動作することを確認
+	t.Run("GetAllSpecTypes from mapping", func(t *testing.T) {
+		types := cfg.GetAllSpecTypes()
+		if len(types) != 2 {
+			t.Errorf("Expected 2 types, got %d", len(types))
+		}
+	})
+
+	// mapping から HasSpecType が動作することを確認
+	t.Run("HasSpecType from mapping", func(t *testing.T) {
+		if !cfg.HasSpecType("ui") {
+			t.Error("Expected ui to exist from mapping")
+		}
+	})
+
+	// mapping から GetSpecTypeInfo が動作することを確認
+	t.Run("GetSpecTypeInfo from mapping", func(t *testing.T) {
+		info := cfg.GetSpecTypeInfo("api")
+		if info == nil {
+			t.Fatal("Expected api info to exist from mapping")
+		}
+		if len(info.CodePaths) != 1 {
+			t.Errorf("Expected 1 code path, got %d", len(info.CodePaths))
+		}
+		if info.CodePaths[0] != "server/routes" {
+			t.Errorf("Expected 'server/routes', got '%s'", info.CodePaths[0])
+		}
+	})
+}
+
+func TestSpecTypesPriorityOverMapping(t *testing.T) {
+	// spec_types と mapping 両方が定義された場合、spec_types が優先されることを確認
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, ".specverify.yml")
+
+	configContent := `
+specs_dir: specs/
+code_dir: src/
+ai_provider: claude
+
+mapping:
+  ui: old/path
+
+spec_types:
+  ui:
+    code_paths:
+      - new/path
+    verification_focus:
+      - 新しい検証観点
+
+options:
+  concurrency: 3
+`
+	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := Load(configFile)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	t.Run("spec_types has priority over mapping", func(t *testing.T) {
+		path := cfg.GetCodePath("ui")
+		if path != "src/new/path" {
+			t.Errorf("Expected spec_types path 'src/new/path', got '%s'", path)
+		}
+	})
+}


### PR DESCRIPTION
## 概要

issue #4 の実装: ビジネスロジック層（ドメイン・モデル等）の検証対応とグループ機能の追加

## 変更内容

### 機能追加

- **spec_types設定**: SPECタイプごとに複数のコードパス、検証観点(verification_focus)を定義可能に
- **groups設定**: 複数のSPECタイプをグループ化して一括検証可能に
- **--group/-gフラグ**: グループ単位での検証実行をサポート
- **複数タイプ指定**: `check ui api domain` のように複数タイプを同時指定可能に
- **types/groupsサブコマンド**: 定義済みタイプ/グループの一覧表示
- **verification_focus連携**: AI検証時にタイプ固有の検証観点をプロンプトに反映

### リファクタリング

- `VerifyAll` を `VerifyMultipleTypes` に委譲（DRY原則）
- プロンプト構築関数の共通化（`buildCodeSection`, `getDefaultVerificationFocus`）

### 後方互換性

- 従来の `mapping` 設定はそのまま動作
- `spec_types` と `mapping` 両方定義時は `spec_types` が優先

### エラーハンドリング

- 存在しないタイプ/グループ指定時に警告を表示
- 無効なタイプを自動除外して検証続行

## テスト

- `TestSpecTypesAndGroups`: 新機能のテスト
- `TestBackwardCompatibility`: 後方互換性テスト
- `TestSpecTypesPriorityOverMapping`: 優先順位テスト

## 設定例

```yaml
spec_types:
  ui:
    code_paths:
      - client/components
      - client/pages
    verification_focus:
      - コンポーネント構成
      - 画面遷移

groups:
  frontend:
    types: [ui]
  backend:
    types: [api, domain, service]
```

## 使用例

```bash
# グループ単位で検証
gh spec-verify check --group backend

# 複数タイプ指定
gh spec-verify check ui api domain

# 定義確認
gh spec-verify types
gh spec-verify groups
```

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)