### PR TITLE
feat: プロジェクト名をgh-spec-verifyからspec-verifyにリネーム

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-# gh-spec-verify
+# spec-verify
 
 SPEC駆動開発のための検証ツール。仕様書（SPEC）と実際のコードが一致しているかをAIで検証します。
 
-**GitHub CLI Extension** として使用できます。
-
 ## 特徴
 
-- **GitHub CLI統合**: `gh spec-verify` コマンドで実行可能
 - **言語非依存**: どのプログラミング言語のプロジェクトでも使用可能
 - **AI検証**: Claude APIを使用して仕様書とコードの一致度を判定
 - **CI対応**: JSON出力でCI/CDパイプラインに組み込み可能
@@ -14,24 +11,18 @@ SPEC駆動開発のための検証ツール。仕様書（SPEC）と実際のコ
 
 ## インストール
 
-### GitHub CLI Extension（推奨）
-
-```bash
-gh extension install k-totani/gh-spec-verify
-```
-
 ### Go Install
 
 ```bash
-go install github.com/k-totani/gh-spec-verify/cmd/gh-spec-verify@latest
+go install github.com/k-totani/spec-verify/cmd/spec-verify@latest
 ```
 
 ### ソースからビルド
 
 ```bash
-git clone https://github.com/k-totani/gh-spec-verify.git
-cd gh-spec-verify
-go build -o gh-spec-verify ./cmd/gh-spec-verify
+git clone https://github.com/k-totani/spec-verify.git
+cd spec-verify
+go build -o spec-verify ./cmd/spec-verify
 ```
 
 ## クイックスタート
@@ -39,7 +30,7 @@ go build -o gh-spec-verify ./cmd/gh-spec-verify
 ### 1. 初期設定
 
 ```bash
-gh spec-verify init
+spec-verify init
 ```
 
 これにより `.specverify.yml` が作成されます。
@@ -63,7 +54,7 @@ specs/
 ### 4. 検証を実行
 
 ```bash
-gh spec-verify check
+spec-verify check
 ```
 
 ## 使い方
@@ -71,46 +62,46 @@ gh spec-verify check
 ### 全てのSPECを検証
 
 ```bash
-gh spec-verify check
+spec-verify check
 ```
 
 ### 特定のタイプのみ検証
 
 ```bash
-gh spec-verify check ui    # UIのSPECのみ
-gh spec-verify check api   # APIのSPECのみ
+spec-verify check ui    # UIのSPECのみ
+spec-verify check api   # APIのSPECのみ
 ```
 
 ### 複数タイプを同時検証
 
 ```bash
-gh spec-verify check ui api domain   # 複数タイプを一度に検証
+spec-verify check ui api domain   # 複数タイプを一度に検証
 ```
 
 ### グループ単位で検証
 
 ```bash
-gh spec-verify check --group frontend   # フロントエンドグループを検証
-gh spec-verify check -g backend         # バックエンドグループを検証
+spec-verify check --group frontend   # フロントエンドグループを検証
+spec-verify check -g backend         # バックエンドグループを検証
 ```
 
 ### 利用可能なタイプ/グループを確認
 
 ```bash
-gh spec-verify types    # 定義されているSPECタイプ一覧
-gh spec-verify groups   # 定義されているグループ一覧
+spec-verify types    # 定義されているSPECタイプ一覧
+spec-verify groups   # 定義されているグループ一覧
 ```
 
 ### JSON出力（CI向け）
 
 ```bash
-gh spec-verify check --format json
+spec-verify check --format json
 ```
 
 ### 合格ラインを指定
 
 ```bash
-gh spec-verify check --threshold 70
+spec-verify check --threshold 70
 ```
 
 ## 設定ファイル
@@ -296,13 +287,13 @@ jobs:
         with:
           go-version: '1.21'
 
-      - name: Install gh-spec-verify
-        run: go install github.com/k-totani/gh-spec-verify/cmd/gh-spec-verify@latest
+      - name: Install spec-verify
+        run: go install github.com/k-totani/spec-verify/cmd/spec-verify@latest
 
       - name: Run verification
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: gh-spec-verify check --format json > spec-verify-result.json
+        run: spec-verify check --format json > spec-verify-result.json
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/cmd/spec-verify/main.go
+++ b/cmd/spec-verify/main.go
@@ -8,10 +8,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/k-totani/gh-spec-verify/internal/ai"
-	"github.com/k-totani/gh-spec-verify/internal/config"
-	"github.com/k-totani/gh-spec-verify/internal/parser"
-	"github.com/k-totani/gh-spec-verify/internal/verifier"
+	"github.com/k-totani/spec-verify/internal/ai"
+	"github.com/k-totani/spec-verify/internal/config"
+	"github.com/k-totani/spec-verify/internal/parser"
+	"github.com/k-totani/spec-verify/internal/verifier"
 )
 
 const version = "0.1.0"
@@ -38,7 +38,7 @@ func main() {
 	case "coverage":
 		runCoverage(os.Args[2:])
 	case "version", "-v", "--version":
-		fmt.Printf("gh-spec-verify version %s\n", version)
+		fmt.Printf("spec-verify version %s\n", version)
 	case "help", "-h", "--help":
 		printUsage()
 	default:
@@ -117,11 +117,11 @@ func (opts commonOptions) buildLoadOptions() []config.LoadOption {
 }
 
 func printUsage() {
-	fmt.Println(`gh-spec-verify - SPEC駆動開発のための検証ツール
+	fmt.Println(`spec-verify - SPEC駆動開発のための検証ツール
 
 Usage:
-  gh spec-verify <command> [options]
-  go run github.com/k-totani/gh-spec-verify/cmd/gh-spec-verify@latest <command> [options]
+  spec-verify <command> [options]
+  go run github.com/k-totani/spec-verify/cmd/spec-verify@latest <command> [options]
 
 Commands:
   init              設定ファイルを初期化
@@ -155,25 +155,25 @@ Environment Variables (優先順位: --api-key > 環境変数 > .env > 設定フ
   既存の環境変数は上書きされません。
 
 Examples:
-  # GitHub CLI Extension として使用
-  gh spec-verify init
-  gh spec-verify check
-  gh spec-verify check ui
+  # 基本的な使い方
+  spec-verify init
+  spec-verify check
+  spec-verify check ui
 
   # go run で直接実行
-  go run github.com/k-totani/gh-spec-verify/cmd/gh-spec-verify@latest check
+  go run github.com/k-totani/spec-verify/cmd/spec-verify@latest check
 
   # APIキーを直接指定
-  gh spec-verify check --api-key sk-xxx
+  spec-verify check --api-key sk-xxx
 
   # 複数タイプ/グループ指定
-  gh spec-verify check domain model          # 複数タイプ指定
-  gh spec-verify check --group backend       # グループ単位で検証
+  spec-verify check domain model          # 複数タイプ指定
+  spec-verify check --group backend       # グループ単位で検証
 
   # CI向け
-  gh spec-verify check --format json
-  gh spec-verify check api --threshold 70
-  gh spec-verify coverage --format json`)
+  spec-verify check --format json
+  spec-verify check api --threshold 70
+  spec-verify coverage --format json`)
 }
 
 func runInit() {
@@ -200,7 +200,7 @@ func runInit() {
 	fmt.Println("1. 設定ファイルを編集してプロジェクトに合わせてください")
 	fmt.Println("2. ANTHROPIC_API_KEY 環境変数を設定してください")
 	fmt.Println("3. specs/ ディレクトリにSPECファイルを配置してください")
-	fmt.Println("4. gh spec-verify check を実行してください")
+	fmt.Println("4. spec-verify check を実行してください")
 }
 
 func runCheck(args []string) {
@@ -248,7 +248,7 @@ func runCheck(args []string) {
 	if commonOpts.groupName != "" {
 		if !cfg.HasGroup(commonOpts.groupName) {
 			fmt.Printf("エラー: グループ '%s' は定義されていません。\n", commonOpts.groupName)
-			fmt.Println("定義済みグループを確認するには: gh spec-verify groups")
+			fmt.Println("定義済みグループを確認するには: spec-verify groups")
 			os.Exit(1)
 		}
 		specTypes = cfg.GetTypesByGroup(commonOpts.groupName)
@@ -264,7 +264,7 @@ func runCheck(args []string) {
 			// 警告はstderrに出力（JSON出力時にも対応）
 			fmt.Fprintf(os.Stderr, "⚠️  警告: グループ '%s' に存在しないタイプが含まれています: %s\n",
 				commonOpts.groupName, strings.Join(undefinedTypes, ", "))
-			fmt.Fprintln(os.Stderr, "定義済みタイプを確認するには: gh spec-verify types")
+			fmt.Fprintln(os.Stderr, "定義済みタイプを確認するには: spec-verify types")
 			// 存在しないタイプを除外して続行
 			validTypes := []string{}
 			for _, typeName := range specTypes {
@@ -292,7 +292,7 @@ func runCheck(args []string) {
 		if len(undefinedTypes) > 0 {
 			// 警告はstderrに出力（JSON出力時にも対応）
 			fmt.Fprintf(os.Stderr, "⚠️  警告: 存在しないタイプが指定されています: %s\n", strings.Join(undefinedTypes, ", "))
-			fmt.Fprintln(os.Stderr, "定義済みタイプを確認するには: gh spec-verify types")
+			fmt.Fprintln(os.Stderr, "定義済みタイプを確認するには: spec-verify types")
 			// 存在しないタイプを除外して続行
 			validTypes := []string{}
 			for _, typeName := range specTypes {
@@ -858,6 +858,6 @@ groups:
 	}
 
 	fmt.Printf("\n使用方法:\n")
-	fmt.Printf("  gh spec-verify check --group <グループ名>\n")
+	fmt.Printf("  spec-verify check --group <グループ名>\n")
 	fmt.Println()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/k-totani/gh-spec-verify
+module github.com/k-totani/spec-verify
 
 go 1.25.5
 

--- a/internal/parser/coverage.go
+++ b/internal/parser/coverage.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/k-totani/gh-spec-verify/internal/ai"
-	"github.com/k-totani/gh-spec-verify/internal/config"
+	"github.com/k-totani/spec-verify/internal/ai"
+	"github.com/k-totani/spec-verify/internal/config"
 )
 
 // CoverageReport はAPIエンドポイントのカバレッジレポート

--- a/internal/parser/endpoint.go
+++ b/internal/parser/endpoint.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/k-totani/gh-spec-verify/internal/ai"
-	"github.com/k-totani/gh-spec-verify/internal/config"
+	"github.com/k-totani/spec-verify/internal/ai"
+	"github.com/k-totani/spec-verify/internal/config"
 )
 
 // Endpoint はAPIエンドポイントを表す

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/k-totani/gh-spec-verify/internal/ai"
-	"github.com/k-totani/gh-spec-verify/internal/config"
-	"github.com/k-totani/gh-spec-verify/internal/parser"
+	"github.com/k-totani/spec-verify/internal/ai"
+	"github.com/k-totani/spec-verify/internal/config"
+	"github.com/k-totani/spec-verify/internal/parser"
 )
 
 // Result は単一のSPEC検証結果


### PR DESCRIPTION
## Summary
- プロジェクト名を `gh-spec-verify` から `spec-verify` に変更
- go.modのモジュールパスを `github.com/k-totani/spec-verify` に更新
- 全ファイルのimportパスを新しいモジュール名に修正
- READMEを更新し、GitHub CLI拡張機能としての記述を削除

## 背景
本ツールはSPEC駆動開発の検証ツールであり、GitHub固有の機能に依存していないため、`gh-` プレフィックスを削除することでツールの汎用性をより明確にしました。

## Test plan
- [x] `go build ./cmd/spec-verify` でビルド確認
- [x] `go test ./...` でテスト実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)