### PR TITLE
feat: coverageコマンドにカテゴリ別表示とfail-underオプションを追加

### DIFF
--- a/internal/parser/endpoint.go
+++ b/internal/parser/endpoint.go
@@ -12,9 +12,10 @@ import (
 	"github.com/k-totani/spec-verify/internal/config"
 )
 
-// Endpoint はAPIエンドポイントを表す
+// Endpoint はルート（API/ページ）を表す
 type Endpoint struct {
 	// HTTPメソッド (GET, POST, PUT, DELETE, PATCH, GRAPHQL等)
+	// ページの場合は "PAGE" や "GET" が設定される
 	Method string `json:"method"`
 
 	// パス (/users/:id など)
@@ -23,6 +24,9 @@ type Endpoint struct {
 	// ソースタイプ (express, openapi, auto等)
 	Source string `json:"source"`
 
+	// カテゴリ (ui, api)
+	Category string `json:"category"`
+
 	// 元ファイルパス
 	File string `json:"file"`
 
@@ -30,7 +34,7 @@ type Endpoint struct {
 	Description string `json:"description,omitempty"`
 }
 
-// ExtractEndpoints は設定に基づいてエンドポイントを抽出する
+// ExtractEndpoints は設定に基づいてルートを抽出する
 func ExtractEndpoints(ctx context.Context, sources []config.APISource, provider ai.Provider) ([]Endpoint, error) {
 	var allEndpoints []Endpoint
 
@@ -49,6 +53,17 @@ func ExtractEndpoints(ctx context.Context, sources []config.APISource, provider 
 
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract endpoints from %s: %w", source.Type, err)
+		}
+
+		// カテゴリを設定
+		category := source.Category
+		if category == "" {
+			category = "api" // デフォルト
+		}
+		for i := range endpoints {
+			if endpoints[i].Category == "" {
+				endpoints[i].Category = category
+			}
 		}
 
 		allEndpoints = append(allEndpoints, endpoints...)


### PR DESCRIPTION
## 概要
coverageコマンドを強化し、UI/APIカテゴリ別のカバレッジ表示機能と`--fail-under`オプションを追加しました。
また、コード品質向上のためセルフレビューを3回実施し、リファクタリングを行いました。

## 機能追加

### coverageコマンドの強化
- **カテゴリ別カバレッジ表示**: UIルート（ページ）とAPIエンドポイントを分けて表示
- **`--fail-under`オプション**: カバレッジが指定した閾値未満の場合に終了コード1を返す（CI向け）
- **route_sources対応**: `api_sources`と`route_sources`を統合して処理

### 出力改善
- カテゴリ別（🖥️ ページ / 🔌 API）のカバレッジをプログレスバー付きで表示
- カバー済み/未カバー/孤立SPECの詳細表示

## リファクタリング（セルフレビュー3回実施）

### DRY原則の適用
- `buildProgressBar()`: プログレスバー生成の共通化
- `getCategoryTag()`, `getCategoryDisplay()`: カテゴリ表示の共通化
- `validateSpecTypes()`: SPECタイプバリデーションの共通化
- `loadConfig()`: 設定読み込みの共通化

### 定数化
- UI定数の追加（`progressBarLength`, `separatorWidthWide/Normal/Narrow`, `maxDisplayItems`）

### 関数分割
- `outputCoverageConsole()`を8つの小関数に分割して可読性向上

### 標準ライブラリ使用
- `config.go`のカスタム文字列関数を`strings.ToLower`/`strings.Contains`に置換

## 使用例

```bash
# カテゴリ別カバレッジレポート
spec-verify coverage

# CI向け: カバレッジ80%未満で失敗
spec-verify coverage --fail-under 80

# JSON出力
spec-verify coverage --format json
```

## テスト
- ✅ `go build ./...` 成功
- ✅ `go test ./...` 成功