### PR TITLE
feat: UIルート（ページ）の抽出機能を追加

### DIFF
--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -28,6 +28,33 @@ type EndpointResult struct {
 	Description string `json:"description,omitempty"`
 }
 
+// カテゴリ定数
+const (
+	CategoryAPI = "api"
+	CategoryUI  = "ui"
+)
+
+// ExtractOptions はエンドポイント抽出時のオプション
+type ExtractOptions struct {
+	// ソースタイプ (express, auto など)
+	SourceType string
+	// カテゴリ (api, ui)
+	Category string
+}
+
+// IsUICategory はUIカテゴリかどうかを判定する
+func (o *ExtractOptions) IsUICategory() bool {
+	return o != nil && o.Category == CategoryUI
+}
+
+// GetSourceType はソースタイプを取得する（nilセーフ）
+func (o *ExtractOptions) GetSourceType() string {
+	if o == nil {
+		return ""
+	}
+	return o.SourceType
+}
+
 // VerifyOptions は検証時のオプション
 type VerifyOptions struct {
 	// 検証観点（AIへのヒント）
@@ -42,8 +69,8 @@ type Provider interface {
 	// VerifyWithOptions は検証観点を指定してSPECとコードの一致度を検証する
 	VerifyWithOptions(ctx context.Context, specContent string, codeContents map[string]string, opts *VerifyOptions) (*VerificationResult, error)
 
-	// ExtractEndpoints はコードからAPIエンドポイントを抽出する
-	ExtractEndpoints(ctx context.Context, sourceType string, codeContent string) ([]EndpointResult, error)
+	// ExtractEndpoints はコードからAPIエンドポイント/ページルートを抽出する
+	ExtractEndpoints(ctx context.Context, opts *ExtractOptions, codeContent string) ([]EndpointResult, error)
 
 	// Name はプロバイダー名を返す
 	Name() string


### PR DESCRIPTION
## 概要

`spec-verify coverage` コマンドでUIルート（フロントエンドのページパス）も抽出できるようになりました。

## 変更内容

### 1. ExtractOptions の追加 (`internal/ai/provider.go`)
- カテゴリ定数 (`CategoryAPI`, `CategoryUI`) を追加
- `ExtractOptions` 構造体を追加（ソースタイプとカテゴリを保持）
- nilセーフなヘルパーメソッド `IsUICategory()`, `GetSourceType()` を追加

### 2. UIルート抽出プロンプトの追加 (`internal/ai/claude.go`)
- `buildUIRouteExtractionPrompt` 関数を追加
- ファイルベースルーティング（Remix、Next.js等）に対応
- ルーター設定ファイルからの抽出にも対応

### 3. globパターン処理の修正 (`internal/parser/endpoint.go`)
- `filepath.Glob` は `**` パターンに対応していない問題を修正
- `**` を含むパターンの場合は `findFilesRecursive` を使用するように変更

## 修正した問題

- `src/client/routes/**/*.tsx` のような `**` パターンが正しく処理されず、UIルートが0件になっていた
- APIルートのみ抽出されてUIルートが抽出されなかった

## テスト結果

- 既存のテストはすべてパス
- ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)