### PR TITLE
デフォルトAIプロバイダーをGeminiに変更

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,7 +106,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		SpecsDir:   "specs/",
 		CodeDir:    "src/",
-		AIProvider: "claude",
+		AIProvider: "gemini",
 		Mapping: map[string]string{
 			"ui":  "client/components",
 			"api": "server/routes",


### PR DESCRIPTION
## 概要
デフォルトのAIプロバイダーをClaudeからGeminiに変更しました。

## 変更内容
- `internal/config/config.go` の `DefaultConfig()` で設定されるデフォルトプロバイダーを `claude` から `gemini` に変更

## 影響
- 設定ファイル（`.specverify.yml`）で `ai_provider` を明示的に指定しない場合、Geminiがデフォルトで使用されます
- 既存の設定ファイルで `ai_provider: claude` を指定している場合は影響ありません

## テスト
- `go test ./internal/config/...` - 全テストパス ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)